### PR TITLE
Netstandard 2.0

### DIFF
--- a/SMSTeknikClient.Tests/SMSTeknikClient.Tests.csproj
+++ b/SMSTeknikClient.Tests/SMSTeknikClient.Tests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-
+    <LangVersion>preview</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/SMSTeknikClient.Tests/UnitTest1.cs
+++ b/SMSTeknikClient.Tests/UnitTest1.cs
@@ -44,7 +44,7 @@ public class Tests
         // TODO: Load actual test configuration from a non-git-committed file. 
         var msg = new OutgoingSmsMessage
         {
-            To = _testConfiguration.Recipients.FirstOrDefault(),
+            To = _testConfiguration.Recipients.First(),
             From = _testConfiguration.From,
             Body = "Hello, World!",
             // You can other stuff here! See documentation for details. 

--- a/SMSTeknikClient.Tests/UnitTest1.cs
+++ b/SMSTeknikClient.Tests/UnitTest1.cs
@@ -44,7 +44,7 @@ public class Tests
         // TODO: Load actual test configuration from a non-git-committed file. 
         var msg = new OutgoingSmsMessage
         {
-            To = _testConfiguration.Recipients.First(),
+            To = _testConfiguration.Recipients.FirstOrDefault(),
             From = _testConfiguration.From,
             Body = "Hello, World!",
             // You can other stuff here! See documentation for details. 

--- a/SMSTeknikClient/ClientImplementation/SmsTeknikXmlClient.cs
+++ b/SMSTeknikClient/ClientImplementation/SmsTeknikXmlClient.cs
@@ -9,6 +9,7 @@ using XE = System.Xml.Linq.XElement;
 
 namespace SMSTeknikClient.ClientImplementation;
 
+/// <inheritdoc />
 public class SmsTeknikXmlClient : ISmsTeknikClient
 {
     private static readonly HttpClient Client = new();

--- a/SMSTeknikClient/ClientImplementation/SmsTeknikXmlClient.cs
+++ b/SMSTeknikClient/ClientImplementation/SmsTeknikXmlClient.cs
@@ -12,7 +12,6 @@ namespace SMSTeknikClient.ClientImplementation;
 public class SmsTeknikXmlClient : ISmsTeknikClient
 {
     private static readonly HttpClient Client = new();
-
     private readonly SmsTeknikConfiguration _config;
 
     public SmsTeknikXmlClient(SmsTeknikConfiguration config)
@@ -24,9 +23,11 @@ public class SmsTeknikXmlClient : ISmsTeknikClient
     void IDisposable.Dispose() =>
         GC.SuppressFinalize(this);
 
+    /// <inheritdoc />
     public async Task<MessageResponse> Send(OutgoingSmsMessage message) =>
         (await Send(new SendRequest(message))).MessageResponses.Single();
 
+    /// <inheritdoc />
     public async Task<SendResponse> Send(SendRequest sendRequest)
     {
         var validationErrors = GetValidationErrors(sendRequest);
@@ -79,7 +80,7 @@ public class SmsTeknikXmlClient : ISmsTeknikClient
             // We have two options: 1) throw exception, or 2) populate the same error message for each of the message response.
             // This scenario only applies when sending to multiple receivers.
             // Example error codes: 0:Access denied, 0:No Valid recipients
-            var errorCode = arrResult.Single()[2..];
+            var errorCode = arrResult.Single().Remove(0, 2);
             throw new Exception("Error: " + errorCode);
         }
 
@@ -100,7 +101,7 @@ public class SmsTeknikXmlClient : ISmsTeknikClient
             {
                 // Error
                 success = false;
-                errorMessage = resultItem[2..];
+                errorMessage = resultItem.Remove(0, 2);
             }
             else
             {
@@ -115,6 +116,7 @@ public class SmsTeknikXmlClient : ISmsTeknikClient
         return new SendResponse(messageResponses);
     }
 
+    /// <inheritdoc />
     public async Task<int> CheckCredits()
     {
         using var responseMessage = await Client.GetAsync("https://api.smsteknik.se/utilities/checkcredits/");

--- a/SMSTeknikClient/ClientImplementation/Utils.cs
+++ b/SMSTeknikClient/ClientImplementation/Utils.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace SMSTeknikClient.ClientImplementation;
 
-public class Utils
+public static class Utils
 {
     public static string Base64Encode(string textToEncode) => 
         Convert.ToBase64String(Encoding.UTF8.GetBytes(textToEncode));
@@ -14,7 +14,7 @@ public class Utils
     /// <returns>Number of chars</returns>
     public static int CalculateMessageLength(string body)
     {
-        var doubleChars = new char[] { '^', '\\', '{', '}', '[', ']', '~', '|', '€', '\n' };
+        var doubleChars = new char[] { '^', '\\', '{', '}', '[', ']', '~', '|', 'ï¿½', '\n' };
 
         int count = 0;
 

--- a/SMSTeknikClient/Config/SmsTeknikConfiguration.cs
+++ b/SMSTeknikClient/Config/SmsTeknikConfiguration.cs
@@ -8,6 +8,6 @@ namespace SMSTeknikClient.Config;
 /// </summary>
 public class SmsTeknikConfiguration
 {
-    public string Password { get; init; }
-    public string Username { get; init; }
+    public string Password { get; set; }
+    public string Username { get; set; }
 }

--- a/SMSTeknikClient/Messages/MessageResponse.cs
+++ b/SMSTeknikClient/Messages/MessageResponse.cs
@@ -1,7 +1,20 @@
 namespace SMSTeknikClient.Messages;
 
-public record MessageResponse(OutgoingSmsMessage OutgoingSmsMessage, bool Success, string? ErrorMessage, long? SmsId)
+public class MessageResponse
 {
+    public MessageResponse(OutgoingSmsMessage outgoingSmsMessage, bool success, string? errorMessage, long? smsId)
+    {
+        OutgoingSmsMessage = outgoingSmsMessage;
+        Success = success;
+        ErrorMessage = errorMessage;
+        SmsId = smsId;
+    }
+    
+    public OutgoingSmsMessage OutgoingSmsMessage { get; }
+    public bool Success { get; }
+    public string? ErrorMessage { get; }
+    public long? SmsId { get; }
+    
     /// <summary>
     /// This method throws an exception if not all of the messages
     /// were sent successfully. Useful as simple check to ensure

--- a/SMSTeknikClient/Messages/MessageResponse.cs
+++ b/SMSTeknikClient/Messages/MessageResponse.cs
@@ -11,9 +11,9 @@ public class MessageResponse
     }
     
     public OutgoingSmsMessage OutgoingSmsMessage { get; }
-    public bool Success { get; }
-    public string? ErrorMessage { get; }
-    public long? SmsId { get; }
+    public bool Success { get; set; }
+    public string? ErrorMessage { get; set; }
+    public long? SmsId { get; set; }
     
     /// <summary>
     /// This method throws an exception if not all of the messages

--- a/SMSTeknikClient/Messages/OutgoingSmsMessage.cs
+++ b/SMSTeknikClient/Messages/OutgoingSmsMessage.cs
@@ -4,13 +4,13 @@ namespace SMSTeknikClient.Messages;
 /// This class represent a single SMS message, with
 /// a single recipient. 
 /// </summary>
-public record OutgoingSmsMessage
+public struct OutgoingSmsMessage
 {
-    public string? From { get; init; }
+    public string? From { get; set; }
 
-    public string? To { get; init; }
+    public string? To { get; set; }
 
-    public string? Body { get; init; }
+    public string? Body { get; set; }
 
     public DateTimeOffset? SendAt { get; set; }
 

--- a/SMSTeknikClient/Messages/SendRequest.cs
+++ b/SMSTeknikClient/Messages/SendRequest.cs
@@ -6,8 +6,10 @@ namespace SMSTeknikClient.Messages;
 ///
 /// Currently no other parameters are defined. 
 /// </summary>
-public record SendRequest(params OutgoingSmsMessage[] OutgoingSmsMessages)
+public class SendRequest(params OutgoingSmsMessage[] outgoingSmsMessages)
 {
+    public OutgoingSmsMessage[] OutgoingSmsMessages { get; } = outgoingSmsMessages;
+
     public static SendRequest FromMessage(OutgoingSmsMessage message) => 
         new(message);
 

--- a/SMSTeknikClient/Messages/SendRequest.cs
+++ b/SMSTeknikClient/Messages/SendRequest.cs
@@ -6,9 +6,14 @@ namespace SMSTeknikClient.Messages;
 ///
 /// Currently no other parameters are defined. 
 /// </summary>
-public class SendRequest(params OutgoingSmsMessage[] outgoingSmsMessages)
+public class SendRequest
 {
-    public OutgoingSmsMessage[] OutgoingSmsMessages { get; } = outgoingSmsMessages;
+    public SendRequest(params OutgoingSmsMessage[] outgoingSmsMessages)
+    {
+        OutgoingSmsMessages = outgoingSmsMessages;
+    }
+    
+    public OutgoingSmsMessage[] OutgoingSmsMessages { get; }
 
     public static SendRequest FromMessage(OutgoingSmsMessage message) => 
         new(message);

--- a/SMSTeknikClient/Messages/SendResponse.cs
+++ b/SMSTeknikClient/Messages/SendResponse.cs
@@ -4,8 +4,14 @@ namespace SMSTeknikClient.Messages;
 /// This class represents the response received
 /// from the SMS teknik server when sending one or more SMS messages. 
 /// </summary>
-public record SendResponse(MessageResponse[] MessageResponses)
+public class SendResponse
 {
+    public SendResponse(MessageResponse[] messageResponses)
+    {
+        MessageResponses = messageResponses;
+    }
+
+    public MessageResponse[] MessageResponses { get; }
     public bool Success => MessageResponses.All(r => r.Success);
 
     /// <summary>

--- a/SMSTeknikClient/SMSTeknikClient.csproj
+++ b/SMSTeknikClient/SMSTeknikClient.csproj
@@ -10,7 +10,8 @@
         <Title>SmsTeknikClient</Title>
         <Authors>SmsTeknik</Authors>
         <PackageProjectUrl>https://github.com/SMSTeknik/</PackageProjectUrl>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>preview</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Converted over to NetStandard 2.0 for further compatibility between platforms.

This removes some of the nicer features that has come to .NET over the years for compatibility reasons.

This may also come with hostbuilder support for adding the client as a scoped service to DI and IHttpClientFactory for managing HttpClients.
Branch: https://github.com/sphexator/SMSTeknikClient/tree/hostbuilder